### PR TITLE
Solve type conflict preventing the pip wheel to build correctly

### DIFF
--- a/src/rlhafnian.h
+++ b/src/rlhafnian.h
@@ -30,6 +30,5 @@ typedef unsigned char sint;
 void haf (double mat[], int n, double res[]);
 telem hafnian (double mat[], int n);
 void evals (double z[], double complex vals[], int n);
-telem hafnian_loops(telem *mat, int n);
 
 #endif


### PR DESCRIPTION
As per subject, this PR tries to fix the following error
```
src/rlhafnian.c: At top level:
src/rlhafnian.c:405:8: error: conflicting types for ‘hafnian_loops’
double hafnian_loops(double *mat, int n)
^~~~~~~~~~~~~
In file included from src/rlhafnian.c:14:
src/rlhafnian.h:33:7: note: previous declaration of ‘hafnian_loops’ was here
telem hafnian_loops(telem *mat, int n);
```
arising when trying to build the *pip wheel* (i.e.: `make wheel`) or installing the package directly from PyPi or git repository.

The error, somehow, falls through CI testing (though still being present in the logfiles).

According to the testsuite, and some specific ad-hoc testing, it shouldn't break things.