### PR TITLE
Adds a wrapper function for numpy.random.seed in samples

### DIFF
--- a/hafnian/samples.py
+++ b/hafnian/samples.py
@@ -550,7 +550,7 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
 
 def seed(seed_val=None):
     r""" Seeds the random number generator used in the sampling algorithms.
-    
+
     This function is a wrapper around ``numpy.random.seed()``. By setting the seed
     to a specific integer, the sampling algorithms will exhibit deterministic behaviour.
 

--- a/hafnian/samples.py
+++ b/hafnian/samples.py
@@ -549,11 +549,12 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
 
 
 def seed(seed_val=None):
-    r""" Seeds the random number generator. It provides a wrapper
-    for numpy.random.seed()
+    r""" Seeds the random number generator used in the sampling algorithms.
+    
+    This function is a wrapper around ``numpy.random.seed()``. By setting the seed
+    to a specific integer, the sampling algorithms will exhibit deterministic behaviour.
 
     Args:
         seed_val (int): Seed for RandomState. Must be convertible to 32 bit unsigned integers.
-
     """
     np.random.seed(seed_val)

--- a/hafnian/samples.py
+++ b/hafnian/samples.py
@@ -70,7 +70,7 @@ from .quantum import (
 # pylint: disable=too-many-branches
 def generate_hafnian_sample(
     cov, mean=None, hbar=2, cutoff=6, max_photons=30, approx=False, approx_samples=1e5
-): # pylint: disable=too-many-branches
+):  # pylint: disable=too-many-branches
     r"""Returns a single sample from the Hafnian of a Gaussian state.
 
     Args:
@@ -490,8 +490,11 @@ def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, pool=False):
     cov = Covmat(Q)
     return torontonian_sample_state(cov, samples, hbar=2, max_photons=max_photons, pool=pool)
 
+
 # pylint: disable=unused-argument
-def hafnian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-08, cutoff=None): # add cutoff for consistency pylint: disable=unused-argument
+def hafnian_sample_classical_state(
+    cov, samples, mean=None, hbar=2, atol=1e-08, cutoff=None
+):  # add cutoff for consistency pylint: disable=unused-argument
     r"""Returns samples from a Gaussian state that has a positive :math:`P` function.
 
     Args:
@@ -543,3 +546,14 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
     return np.where(
         hafnian_sample_classical_state(cov, samples, mean=mean, hbar=hbar, atol=atol) > 0, 1, 0
     )
+
+
+def seed(seed_val=None):
+    r""" Seeds the random number generator. It provides a wrapper
+    for numpy.random.seed()
+
+    Args:
+        seed_val (int): Seed for RandomState. Must be convertible to 32 bit unsigned integers.
+
+    """
+    np.random.seed(seed_val)

--- a/hafnian/tests/test_samples.py
+++ b/hafnian/tests/test_samples.py
@@ -24,10 +24,11 @@ from hafnian.samples import (
     torontonian_sample_state,
     hafnian_sample_classical_state,
     torontonian_sample_classical_state,
+    seed,
 )
 from hafnian.quantum import gen_Qmat_from_graph, density_matrix_element
 
-np.random.seed(137)
+seed(137)
 
 rel_tol = 3.0
 abs_tol = 1.0e-10

--- a/hafnian/tests/test_samples.py
+++ b/hafnian/tests/test_samples.py
@@ -413,3 +413,19 @@ class TestTorontonianSampling:
         probs[0] = 1.0 / (1.0 + mean_n)
         probs[1] = 1 - probs[0]
         assert np.all(np.abs(rel_freq - probs) < rel_tol / np.sqrt(n_samples))
+
+
+def test_seed():
+    """Tests that seed method does reset the random number generators"""
+    n_samples = 10
+    mean_n = 1.0
+    r = np.arcsinh(np.sqrt(mean_n))
+    V = np.array([[np.exp(2 * r), 0.0], [0.0, np.exp(-2 * r)]])
+    seed(137)
+    first_sample = hafnian_sample_state(V, n_samples)
+    second_sample = hafnian_sample_state(V, n_samples)
+    seed(137)
+    first_sample_p = hafnian_sample_state(V, n_samples)
+    second_sample_p = hafnian_sample_state(V, n_samples)
+    assert np.array_equal(first_sample, first_sample_p)
+    assert np.array_equal(second_sample, second_sample_p)


### PR DESCRIPTION
**Description of the Change:**
Adds a seed wrapper function.
**Benefits:**
A call from within hafnian can now be used to make the tests deterministic.
**Possible Drawbacks:**

**Related GitHub Issues:**
